### PR TITLE
Use module.exports instead of exports.default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,4 +27,4 @@ function aliasImporter (alias) {
 	};
 }
 
-exports.default = aliasImporter;
+module.exports = aliasImporter;


### PR DESCRIPTION
Currently you cannot use the module as it is shown in the example. Consider the following example which uses require to import the `node-sass-importer-alias` module.
**Before PR:**
```
$ node
> var importAlias = require('node-sass-importer-alias');
> importAlias
{ default: [Function: aliasImporter] }
> importAlias(/* some arguments */);
TypeError: importAlias is not a function
```
**After PR:**
```
$ node
> var importAlias = require('node-sass-importer-alias');
> importAlias
[Function: aliasImporter]
> importAlias(/* some arguments */);
[Function: importer]
```

As you can see the variable `importAlias` is not a function. To fix this problem I changed the export behaviour. You can now directly import the importAlias function using `require`.
This should also fix this issue ReiMcCl/node-sass-importer-alias#1.